### PR TITLE
Deal with activity property ExcludeFromRecents, to avoid Mobile Legnends has two recent task problem

### DIFF
--- a/VirtualApp/lib/src/main/AndroidManifest.xml
+++ b/VirtualApp/lib/src/main/AndroidManifest.xml
@@ -1005,6 +1005,406 @@
             android:taskAffinity="com.lody.virtual.vt"
             android:theme="@android:style/Theme.Dialog" />
 
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C0"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p0"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C1"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p1"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C2"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p2"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C3"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p3"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C4"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p4"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C5"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p5"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C6"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p6"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C7"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p7"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C8"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p8"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C9"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p9"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C10"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p10"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C11"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p11"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C12"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p12"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C13"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p13"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C14"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p14"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C15"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p15"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C16"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p16"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C17"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p17"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C18"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p18"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C19"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p19"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C20"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p20"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C21"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p21"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C22"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p22"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C23"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p23"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C24"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p24"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C25"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p25"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C26"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p26"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C27"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p27"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C28"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p28"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C29"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p29"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C30"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p30"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C31"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p31"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C32"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p32"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C33"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p33"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C34"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p34"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C35"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p35"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C36"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p36"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C37"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p37"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C38"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p38"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C39"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p39"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C40"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p40"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C41"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p41"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C42"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p42"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C43"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p43"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C44"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p44"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C45"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p45"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C46"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p46"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C47"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p47"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C48"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p48"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
+        <activity
+            android:name="com.lody.virtual.client.stub.StubExcludeFromRecentActivity$C49"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
+            android:process=":p49"
+            android:excludeFromRecents="true"
+            android:taskAffinity="com.lody.virtual.vt"
+            android:theme="@style/VATheme" />
+
         <provider
             android:name="com.lody.virtual.client.stub.StubCP$C0"
             android:authorities="${applicationId}.virtual_stub_0"

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubExcludeFromRecentActivity.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubExcludeFromRecentActivity.java
@@ -1,0 +1,161 @@
+package com.lody.virtual.client.stub;
+
+/**
+ * deal with Activity manifest property excludeFromRecents
+ * deal with the bug : Mobile Legends has two recent task
+ * added by xiawanli,  2018.9.6
+ */
+public abstract class StubExcludeFromRecentActivity extends StubActivity {
+
+    public static class C0 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C1 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C2 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C3 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C4 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C5 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C6 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C7 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C8 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C9 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C10 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C11 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C12 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C13 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C14 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C15 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C16 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C17 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C18 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C19 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C20 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C21 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C22 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C23 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C24 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C25 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C26 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C27 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C28 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C29 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C30 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C31 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C32 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C33 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C34 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C35 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C36 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C37 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C38 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C39 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C40 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C41 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C42 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C43 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C44 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C45 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C46 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C47 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C48 extends StubExcludeFromRecentActivity {
+    }
+
+    public static class C49 extends StubExcludeFromRecentActivity {
+    }
+
+
+}

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/VASettings.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/VASettings.java
@@ -14,6 +14,7 @@ public class VASettings {
     public static String STUB_CP = StubCP.class.getName();
     public static String STUB_JOB = StubJob.class.getName();
     public static String RESOLVER_ACTIVITY = ResolverActivity.class.getName();
+    public static String STUB_EXCLUDE_FROM_RECENT_ACTIVITY = StubExcludeFromRecentActivity.class.getName();
     public static String STUB_CP_AUTHORITY = "virtual_stub_";
     public static int STUB_COUNT = 50;
     public static String[] PRIVILEGE_APPS = new String[]{
@@ -33,6 +34,10 @@ public class VASettings {
      * we redirect it to '/data/data/{Your Host Package Name}/virtual/user/0/{Package Name}'.
      */
     public static boolean ENABLE_IO_REDIRECT = true;
+
+    public static String getStubExcludeFromRecentActivityName(int index) {
+        return String.format(Locale.ENGLISH, "%s$C%d", STUB_EXCLUDE_FROM_RECENT_ACTIVITY, index);
+    }
 
     public static String getStubActivityName(int index) {
         return String.format(Locale.ENGLISH, "%s$C%d", STUB_ACTIVITY, index);

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/am/ActivityStack.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/am/ActivityStack.java
@@ -542,6 +542,12 @@ import static android.content.pm.ActivityInfo.LAUNCH_SINGLE_TOP;
             e.printStackTrace();
         }
 
+        // deal with manifest Activity style android:excludeFromRecents="true", becasue Mobile Legends has two recent task
+        boolean isExcludeFromRecents = ((targetInfo.flags & ActivityInfo.FLAG_EXCLUDE_FROM_RECENTS) != 0);
+        if (isExcludeFromRecents) {
+            return VASettings.getStubExcludeFromRecentActivityName(vpid);
+        }
+
         boolean isDialogStyle = isFloating || isTranslucent || showWallpaper;
         if (isDialogStyle) {
             return VASettings.getStubDialogName(vpid);


### PR DESCRIPTION
Deal with activity property excludeFromRecents.
The app Mobile Legnends has two tasks in the recent task  list, when launching from VituralXposed.