### PR TITLE
[bugfix][android 9 无网络]：解决当真机环境为 Android9.0 时，虚拟环境中 app无网络的缺陷

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/ipc/VPackageManager.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/ipc/VPackageManager.java
@@ -185,7 +185,7 @@ public class VPackageManager {
             }
             final int P = 28;
             final String APACHE_LEGACY = "/system/framework/org.apache.http.legacy.boot.jar";
-            if (android.os.Build.VERSION.SDK_INT >= P && info.targetSdkVersion < P) {
+            if (android.os.Build.VERSION.SDK_INT >= P && info.targetSdkVersion <= P) {
                 String[] newSharedLibraryFiles;
                 if (info.sharedLibraryFiles == null) {
                     newSharedLibraryFiles = new String[]{APACHE_LEGACY};


### PR DESCRIPTION
解决当真机环境为 Android9.0 时，且虚拟环境中 app的info.targetSdkVersion=28时，无网络访问的缺陷，info.targetSdkVersion=28 应改为 info.targetSdkVersion<=28