### PR TITLE
Resolve dependencies(jcenter, etc)

### DIFF
--- a/VirtualApp/app/build.gradle
+++ b/VirtualApp/app/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     //Promise Support
     implementation 'org.jdeferred:jdeferred-android-aar:1.2.4'
     // ThirdParty
-    implementation 'com.jonathanfinerty.once:once:1.0.3'
+    implementation 'com.jonathanfinerty.once:once:1.3.1'
 
     def appCenterSdkVersion = '3.0.0'
     aospImplementation("com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}")

--- a/VirtualApp/build.gradle
+++ b/VirtualApp/build.gradle
@@ -27,6 +27,7 @@ allprojects {
             name 'Google'
         }
         jcenter()
+        maven { url 'https://verve.jfrog.io/artifactory/verve-gradle-release' }
     }
 }
 

--- a/VirtualApp/lib/build.gradle
+++ b/VirtualApp/lib/build.gradle
@@ -39,7 +39,8 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    api("me.weishu.exposed:exposed-core:0.8.1") {
+    // api("me.weishu.exposed:exposed-core:0.8.1") {
+    api('com.github.android-hacker:exposed:0.3.6') {
         exclude group: 'me.weishu', module: 'free_reflection'
         exclude group: 'me.weishu', module: 'epic'
         exclude group: 'me.weishu.exposed', module: 'exposed-xposedapi'


### PR DESCRIPTION
Currently dependencies of `vxp` are broken.
This PR is compact workaround for successful build.

- Added Repositories
  - `maven { url 'https://verve.jfrog.io/artifactory/verve-gradle-release' }`

- Changed
  - Removed `api("me.weishu.exposed:exposed-core:0.8.1") {`
  - Added `api('com.github.android-hacker:exposed:0.3.6') {`
  - Removed `com.jonathanfinerty.once:once:1.0.3`
  - Added `com.jonathanfinerty.once:once:1.3.1`

# How to build
Use WSL, Do not use Android Studio or Windows (at least, I failed)
Use Java lower version like 8.
Do not change gradle version.
Use Android NDK 22 or lower like 21. (need platform directory in ndk)
``` bash
./gradlew build
```
## You already done
You can get
```
keytool -printcert -jarfile app/build/outputs/apk/aosp/debug/app-aosp-debug.apk
```