### PR TITLE
ci(build): Upgrade GitHub Actions workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,25 +4,37 @@ on: [pull_request, push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    
     steps:
-    - uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: srt32/git-actions@v0.0.3
+    - uses: actions/checkout@v6
       with:
-        args: git submodule update --init --recursive
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
+        submodules: recursive
+    
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v5
       with:
-        java-version: 1.8
+        distribution: 'temurin'
+        java-version: '8'
+        cache: gradle
+    
+    - name: Setup Android NDK
+      uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        ndk-version: r21e
+        local-cache: true
+    
     - name: Build with Gradle
-      run: cd VirtualApp && ./gradlew assembleRelease
-    - name: ls
-      run: ls
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+      run: |
+        cd VirtualApp
+        chmod +x gradlew
+        ./gradlew assembleDebug
+    
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
-        name: compiled
-        path: VirtualApp/app/build/
+        name: VirtualXposed-APK
+        path: VirtualApp/app/build/outputs/apk/**/*.apk


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building the Android project. The main improvements include upgrading to newer action versions, improving dependency management, and enhancing the build environment setup for better reliability and performance.

**CI/CD workflow modernization and improvements:**

* Upgraded `actions/checkout` to v6 and enabled recursive submodule checkout.
* Replaced the old submodule checkout action (`srt32/git-actions`) with the built-in `actions/checkout` submodule support, simplifying the workflow.
* Upgraded `actions/setup-java` to v5, switched to the Temurin distribution, enabled Gradle caching, and improved version specification for more consistent Java setup.
* Added a dedicated step to set up the Android NDK using `nttld/setup-ndk@v1`, with local caching and explicit versioning, and configured the build environment to use the NDK path.
* Updated the Gradle build step to ensure the wrapper is executable and switched the build variant from `assembleRelease` to `assembleDebug` for development builds.
* Upgraded `actions/upload-artifact` to v6 and refined the artifact path to only